### PR TITLE
Support node@22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.18.0
+
+### Updates
+
+- Added support for node 22;
+- Upgraded `connectycube` >=4.2.1 to use import types and enums from "connectycube/types".
+
 ## 0.17.0
 
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Updates
 
 - Added support for node 22;
-- Upgraded `connectycube` >=4.2.1 to use import types and enums from "connectycube/types".
+- Upgraded `connectycube` >=4.2.2 to use import types and enums from "connectycube/types".
 
 ## 0.17.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,17 @@
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
+        "@types/node": "^22.13.10",
         "@types/react": "^19.0.10",
         "prettier": "^3.5.3",
         "rollup": "^4.36.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "tslib": "^2.8.1",
         "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.36.0"
@@ -493,6 +498,16 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.0.10",
@@ -1636,6 +1651,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,22 +13,22 @@
         "react-usestateref": "^1.0.9"
       },
       "devDependencies": {
-        "@rollup/plugin-commonjs": "^28.0.2",
-        "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-commonjs": "^28.0.3",
+        "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/react": "^19.0.10",
         "prettier": "^3.5.3",
-        "rollup": "^4.34.9",
+        "rollup": "^4.36.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "tslib": "^2.8.1",
         "typescript": "^5.8.2"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.34.9"
+        "@rollup/rollup-linux-x64-gnu": "^4.36.0"
       },
       "peerDependencies": {
-        "connectycube": ">=4.1.3",
+        "connectycube": ">=4.2.0",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.2.tgz",
-      "integrity": "sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==",
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.3.tgz",
+      "integrity": "sha512-pyltgilam1QPdn+Zd9gaCfOLcnjMEJ9gV+bTw6/r73INdvzf1ah9zLIJBm+kW7R6IUFIQ1YO+VqZtYxZNWFPEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.0.tgz",
-      "integrity": "sha512-0FPvAeVUT/zdWoO0jnb/V5BlBsUSNfkIOtFHzMO4H9MOklrmQFY6FduVHKucNb/aTFxvnGhj4MNj/T1oNdDfNg==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz",
+      "integrity": "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
-      "integrity": "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.36.0.tgz",
+      "integrity": "sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==",
       "cpu": [
         "arm"
       ],
@@ -237,9 +237,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.9.tgz",
-      "integrity": "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.36.0.tgz",
+      "integrity": "sha512-NyfuLvdPdNUfUNeYKUwPwKsE5SXa2J6bCt2LdB/N+AxShnkpiczi3tcLJrm5mA+eqpy0HmaIY9F6XCa32N5yzg==",
       "cpu": [
         "arm64"
       ],
@@ -251,9 +251,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
-      "integrity": "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.36.0.tgz",
+      "integrity": "sha512-JQ1Jk5G4bGrD4pWJQzWsD8I1n1mgPXq33+/vP4sk8j/z/C2siRuxZtaUA7yMTf71TCZTZl/4e1bfzwUmFb3+rw==",
       "cpu": [
         "arm64"
       ],
@@ -265,9 +265,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
-      "integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.36.0.tgz",
+      "integrity": "sha512-6c6wMZa1lrtiRsbDziCmjE53YbTkxMYhhnWnSW8R/yqsM7a6mSJ3uAVT0t8Y/DGt7gxUWYuFM4bwWk9XCJrFKA==",
       "cpu": [
         "x64"
       ],
@@ -279,9 +279,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.9.tgz",
-      "integrity": "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.36.0.tgz",
+      "integrity": "sha512-KXVsijKeJXOl8QzXTsA+sHVDsFOmMCdBRgFmBb+mfEb/7geR7+C8ypAml4fquUt14ZyVXaw2o1FWhqAfOvA4sg==",
       "cpu": [
         "arm64"
       ],
@@ -293,9 +293,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.9.tgz",
-      "integrity": "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.36.0.tgz",
+      "integrity": "sha512-dVeWq1ebbvByI+ndz4IJcD4a09RJgRYmLccwlQ8bPd4olz3Y213uf1iwvc7ZaxNn2ab7bjc08PrtBgMu6nb4pQ==",
       "cpu": [
         "x64"
       ],
@@ -307,9 +307,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.9.tgz",
-      "integrity": "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.36.0.tgz",
+      "integrity": "sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==",
       "cpu": [
         "arm"
       ],
@@ -321,9 +321,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.9.tgz",
-      "integrity": "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.36.0.tgz",
+      "integrity": "sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==",
       "cpu": [
         "arm"
       ],
@@ -335,9 +335,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
-      "integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.36.0.tgz",
+      "integrity": "sha512-KqjYVh3oM1bj//5X7k79PSCZ6CvaVzb7Qs7VMWS+SlWB5M8p3FqufLP9VNp4CazJ0CsPDLwVD9r3vX7Ci4J56A==",
       "cpu": [
         "arm64"
       ],
@@ -349,9 +349,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
-      "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.36.0.tgz",
+      "integrity": "sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==",
       "cpu": [
         "arm64"
       ],
@@ -363,9 +363,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.9.tgz",
-      "integrity": "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.36.0.tgz",
+      "integrity": "sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==",
       "cpu": [
         "loong64"
       ],
@@ -377,9 +377,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.9.tgz",
-      "integrity": "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.36.0.tgz",
+      "integrity": "sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==",
       "cpu": [
         "ppc64"
       ],
@@ -391,9 +391,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.9.tgz",
-      "integrity": "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.36.0.tgz",
+      "integrity": "sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==",
       "cpu": [
         "riscv64"
       ],
@@ -405,9 +405,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.9.tgz",
-      "integrity": "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.36.0.tgz",
+      "integrity": "sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==",
       "cpu": [
         "s390x"
       ],
@@ -419,9 +419,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
-      "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.36.0.tgz",
+      "integrity": "sha512-5KtoW8UWmwFKQ96aQL3LlRXX16IMwyzMq/jSSVIIyAANiE1doaQsx/KRyhAvpHlPjPiSU/AYX/8m+lQ9VToxFQ==",
       "cpu": [
         "x64"
       ],
@@ -432,9 +432,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
-      "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.36.0.tgz",
+      "integrity": "sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==",
       "cpu": [
         "x64"
       ],
@@ -446,9 +446,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
-      "integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.36.0.tgz",
+      "integrity": "sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==",
       "cpu": [
         "arm64"
       ],
@@ -460,9 +460,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.9.tgz",
-      "integrity": "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.36.0.tgz",
+      "integrity": "sha512-t+RY0JuRamIocMuQcfwYSOkmdX9dtkr1PbhKW42AMvaDQa+jOdpUYysroTF/nuPpAaQMWp7ye+ndlmmthieJrQ==",
       "cpu": [
         "ia32"
       ],
@@ -474,9 +474,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
-      "integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.36.0.tgz",
+      "integrity": "sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==",
       "cpu": [
         "x64"
       ],
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.5.tgz",
-      "integrity": "sha512-GLZPrd9ckqEBFMcVM/qRFAP0Hg3qiVEojgEFsx/N/zKXsBzbGF6z5FBDpZ0+Xhp1xr+qRZYjfGr1cWHB9oFHSA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -655,9 +655,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "22.10.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.9.tgz",
-      "integrity": "sha512-Ir6hwgsKyNESl/gLOcEz3krR4CBGgliDqBQ2ma4wIhEx0w+xnoeTq3tdrNw15kU3SxogDjOgv9sqdtLW8mIHaw==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1178,9 +1178,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1238,6 +1238,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1246,9 +1253,9 @@
       "license": "MIT"
     },
     "node_modules/connectycube": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/connectycube/-/connectycube-4.1.3.tgz",
-      "integrity": "sha512-h+HtSPbU/oOVPRJ0tA12BmyO7/bQFWT5vL9GzKek979xAgfgZGH1WGc520Z4mEmwCQgIgAOq/hHHLqUgME7M2g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/connectycube/-/connectycube-4.2.0.tgz",
+      "integrity": "sha512-+mPhZEvaXuFwY4hjPgt3jynx+sly9f4chk9Yt+tfPvI+FJVSTeO42FLTZHi4MKdtzETphhS3c8jj5Lxi8FaSfg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1500,18 +1507,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -1826,9 +1833,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
-      "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.36.0.tgz",
+      "integrity": "sha512-zwATAXNQxUcd40zgtQG0ZafcRK4g004WtEl7kbuhTWPvf07PsfohXl39jVUvPF7jvNAIkKPQ2XrsDlWuxBd++Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1842,25 +1849,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.34.9",
-        "@rollup/rollup-android-arm64": "4.34.9",
-        "@rollup/rollup-darwin-arm64": "4.34.9",
-        "@rollup/rollup-darwin-x64": "4.34.9",
-        "@rollup/rollup-freebsd-arm64": "4.34.9",
-        "@rollup/rollup-freebsd-x64": "4.34.9",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.9",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.9",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.9",
-        "@rollup/rollup-linux-arm64-musl": "4.34.9",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.9",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.9",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.9",
-        "@rollup/rollup-linux-x64-gnu": "4.34.9",
-        "@rollup/rollup-linux-x64-musl": "4.34.9",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.9",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.9",
-        "@rollup/rollup-win32-x64-msvc": "4.34.9",
+        "@rollup/rollup-android-arm-eabi": "4.36.0",
+        "@rollup/rollup-android-arm64": "4.36.0",
+        "@rollup/rollup-darwin-arm64": "4.36.0",
+        "@rollup/rollup-darwin-x64": "4.36.0",
+        "@rollup/rollup-freebsd-arm64": "4.36.0",
+        "@rollup/rollup-freebsd-x64": "4.36.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.36.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.36.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.36.0",
+        "@rollup/rollup-linux-arm64-musl": "4.36.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.36.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.36.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.36.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.36.0",
+        "@rollup/rollup-linux-x64-gnu": "4.36.0",
+        "@rollup/rollup-linux-x64-musl": "4.36.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.36.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.36.0",
+        "@rollup/rollup-win32-x64-msvc": "4.36.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -1981,9 +1988,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1998,13 +2005,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -2070,9 +2070,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@rollup/rollup-linux-x64-gnu": "^4.36.0"
       },
       "peerDependencies": {
-        "connectycube": ">=4.2.0",
+        "connectycube": ">=4.2.2",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
@@ -487,207 +487,12 @@
         "win32"
       ]
     },
-    "node_modules/@types/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/content-disposition": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
-      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/cookies": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
-      "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/events": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
-      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/express": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
-      "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/form-data": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.2.tgz",
-      "integrity": "sha512-tfmcyHn1Pp9YHAO5r40+UuZUPAZbUEgqTel3EuEKpmF9hPkXgR4l41853raliXnb4gwyPNoQOfvgGGlHN5WSog==",
-      "deprecated": "This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "form-data": "*"
-      }
-    },
-    "node_modules/@types/http-assert": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
-      "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/keygrip": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/koa": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
-      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/accepts": "*",
-        "@types/content-disposition": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/http-errors": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/koa-compose": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
-      "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/ltx": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ltx/-/ltx-3.1.0.tgz",
-      "integrity": "sha512-fkYKRqE7oAtqlImS4JvRP7PqFHJVCv7Dn7k8MOhz6u/MjnC9JOCbLdOb7Q0KfSYDQgtPJecH10A23UfuzZSsQA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/events": "*"
-      }
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.20.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.18",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
-      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.0.10",
@@ -705,205 +510,6 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/saslmechanisms": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@types/saslmechanisms/-/saslmechanisms-0.1.3.tgz",
-      "integrity": "sha512-HUgi9jPWUy3T1kafWyA6EImXytjXVu+xupRaYgEQhP0H8wb3W02i0zgmJM0BVsGSvYfuAL/oD/TE5h3BQ/7JVg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/xmpp__client": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__client/-/xmpp__client-0.13.3.tgz",
-      "integrity": "sha512-YiKUD9ex+4lrO3S6GbMkw7DKcJnfgj34GNCvKymxfgFMq66ZR5Z8PV+sdIYsgjJw8c7MjmhUAX2iTW5ouR8rrA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/koa-compose": "*",
-        "@types/xmpp__client-core": "*",
-        "@types/xmpp__connection": "*",
-        "@types/xmpp__iq": "*",
-        "@types/xmpp__middleware": "*",
-        "@types/xmpp__reconnect": "*",
-        "@types/xmpp__resource-binding": "*",
-        "@types/xmpp__sasl": "*",
-        "@types/xmpp__stream-features": "*",
-        "@types/xmpp__stream-management": "*"
-      }
-    },
-    "node_modules/@types/xmpp__client-core": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__client-core/-/xmpp__client-core-0.13.3.tgz",
-      "integrity": "sha512-ZZAQeZMG05wQjRNXePUPIP1/xhCiptoNSPATtZjM6310IHU8F5seb+5Ii7EUmKa/ew61KjPe1+TztEFPcqtQcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/xmpp__connection": "*",
-        "@types/xmpp__jid": "*",
-        "@types/xmpp__xml": "*"
-      }
-    },
-    "node_modules/@types/xmpp__connection": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__connection/-/xmpp__connection-0.13.3.tgz",
-      "integrity": "sha512-WqW5VEyARmUzDiX++yFQbtPCFee7uWGcd5wcdMQXkl7SMKTFioxPbPbKVe8eOFsnUhq+6uxLrkUJqVlCumelCQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/xmpp__error": "*",
-        "@types/xmpp__events": "*",
-        "@types/xmpp__jid": "*",
-        "@types/xmpp__xml": "*"
-      }
-    },
-    "node_modules/@types/xmpp__error": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__error/-/xmpp__error-0.13.3.tgz",
-      "integrity": "sha512-N7/PUc4+Q5aRDJ4Ipm9NbtKiCNHR763Z+9CdPQpc/PElwblsy62gJEmBgKj8d4yotMn9pwNMEg9NHcFh2mTBZQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/xmpp__xml": "*"
-      }
-    },
-    "node_modules/@types/xmpp__events": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__events/-/xmpp__events-0.13.3.tgz",
-      "integrity": "sha512-GW844fKApo5wRg2MUlceETZFAdKO2zqElAQJZaR41oqDn5uv0BfnFUAbJ1MCGeyO0Ul0pyNw3m5/mzskiM/u2A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/xmpp__iq": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__iq/-/xmpp__iq-0.13.4.tgz",
-      "integrity": "sha512-bMZVX6EWdrEOLud5gW8ducc0DGDH9JSQYEXMIeQYEmE4VjFiWDAo30dhVyeSqYwM4K6GaS9rnOdHvysMUE8iKA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/koa-compose": "*",
-        "@types/xmpp__events": "*",
-        "@types/xmpp__middleware": "*",
-        "@types/xmpp__xml": "*"
-      }
-    },
-    "node_modules/@types/xmpp__jid": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__jid/-/xmpp__jid-1.3.5.tgz",
-      "integrity": "sha512-7nbg+XOOswcLAqjU6f5qBzdmoMw8JvcpPP36O+DACZyPAi88LGw8ulmy05F7jpvjXlGAFGrFvnmF5d9OrU+LfQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/xmpp__middleware": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__middleware/-/xmpp__middleware-0.13.3.tgz",
-      "integrity": "sha512-qzqsJ1ZgkW9zezkkWGcMfvAx0XurYhMBr5E3txYCBi2OX+ATWv1eFFz1fxFWeYoEhtZSqr6BU9BHzd5BQW0RIg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/koa-compose": "*",
-        "@types/xmpp__connection": "*",
-        "@types/xmpp__error": "*",
-        "@types/xmpp__jid": "*",
-        "@types/xmpp__xml": "*"
-      }
-    },
-    "node_modules/@types/xmpp__reconnect": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__reconnect/-/xmpp__reconnect-0.13.3.tgz",
-      "integrity": "sha512-PaOmUCuwMKXHsIN02uN23GErOeBzo6MwZYDdbH5S3GCFo7eLVPH9xPeXNW74/be3Dp6+CzDfHhr46efNSG6kww==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/xmpp__connection": "*",
-        "@types/xmpp__events": "*"
-      }
-    },
-    "node_modules/@types/xmpp__resource-binding": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__resource-binding/-/xmpp__resource-binding-0.13.3.tgz",
-      "integrity": "sha512-05Tta9Cj0anOXU8imZtBLDt4YnmVhxiMcSDXNZfqFi0oBP03cettJvTKudD2azimRsuEF94jIMmJ8z7dat0V4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/xmpp__iq": "*",
-        "@types/xmpp__middleware": "*",
-        "@types/xmpp__stream-features": "*",
-        "@types/xmpp__xml": "*"
-      }
-    },
-    "node_modules/@types/xmpp__sasl": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__sasl/-/xmpp__sasl-0.13.6.tgz",
-      "integrity": "sha512-2sXw7oewQ7U2a+NAKeYrIHXsLnrl5oqHi/vzr2Fl/5GmEFSWQEG2g3wqnhs16k2VxvslOY9rY9tY2uKd8Iz77g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/saslmechanisms": "*",
-        "@types/xmpp__error": "*",
-        "@types/xmpp__middleware": "*",
-        "@types/xmpp__stream-features": "*"
-      }
-    },
-    "node_modules/@types/xmpp__stream-features": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__stream-features/-/xmpp__stream-features-0.13.3.tgz",
-      "integrity": "sha512-PgylX899T/yFQnPbBciMbdhXuM4XMLhThzwYzWPnlzo7hms88nSkJZrRYiemlSUqZ1z8VzwcsHTa2/CduUeF5w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/koa": "*",
-        "@types/koa-compose": "*",
-        "@types/xmpp__middleware": "*",
-        "@types/xmpp__xml": "*"
-      }
-    },
-    "node_modules/@types/xmpp__stream-management": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__stream-management/-/xmpp__stream-management-0.13.3.tgz",
-      "integrity": "sha512-KMcRL30R4WzZKghsPbbOUrEMbh8PWsGo2e6IiAK3PzUDWvSA7z+MQl0K9BVI2DHYhqCFI+qxKIYSoahdagR7lw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/xmpp__middleware": "*",
-        "@types/xmpp__stream-features": "*"
-      }
-    },
-    "node_modules/@types/xmpp__xml": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@types/xmpp__xml/-/xmpp__xml-0.13.4.tgz",
-      "integrity": "sha512-j5cRnNJPvLhjCDpKZC+2g0HdMPqmA2xD417P1JKxEZlhQkfKrsCeBi20dsUHaVZJ/NFChkrr/bqW5bE9Oq5luw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/ltx": "*"
-      }
     },
     "node_modules/@xmpp/base64": {
       "version": "0.13.2",
@@ -1253,15 +859,12 @@
       "license": "MIT"
     },
     "node_modules/connectycube": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/connectycube/-/connectycube-4.2.0.tgz",
-      "integrity": "sha512-+mPhZEvaXuFwY4hjPgt3jynx+sly9f4chk9Yt+tfPvI+FJVSTeO42FLTZHi4MKdtzETphhS3c8jj5Lxi8FaSfg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/connectycube/-/connectycube-4.2.2.tgz",
+      "integrity": "sha512-PL7EkvI/u4+9cxI1bn+FtnEFYOgW4lVudOubANCfshqPaaHYw6658CyPJdIPUucWLIUFB2DLcj5N0a4Llx1XSA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@types/form-data": "^2.5.2",
-        "@types/node-fetch": "^2.6.12",
-        "@types/xmpp__client": "^0.13.3",
         "@xmpp/client-core": "^0.13.3",
         "@xmpp/iq": "^0.13.3",
         "@xmpp/middleware": "^0.13.3",
@@ -2033,13 +1636,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "connectycube": ">=4.2.0",
+    "connectycube": ">=4.2.1",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/react": "^19.0.10",
+    "@types/node": "^22.13.10",
     "prettier": "^3.5.3",
     "rollup": "^4.36.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -39,23 +39,23 @@
     "react-usestateref": "^1.0.9"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^28.0.2",
-    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-commonjs": "^28.0.3",
+    "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/react": "^19.0.10",
     "prettier": "^3.5.3",
-    "rollup": "^4.34.9",
+    "rollup": "^4.36.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "tslib": "^2.8.1",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "connectycube": ">=4.1.3",
+    "connectycube": ">=4.2.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.34.9"
+    "@rollup/rollup-linux-x64-gnu": "^4.36.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "connectycube": ">=4.2.1",
+    "connectycube": ">=4.2.2",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -57,5 +57,9 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.36.0"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,7 +5,10 @@ import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import terser from "@rollup/plugin-terser";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
-import packageJson from './package.json' assert { type: 'json' };
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('./package.json');
 
 const globals = {
   "connectycube": "ConnectyCube",

--- a/src/ChatContext.tsx
+++ b/src/ChatContext.tsx
@@ -181,7 +181,7 @@ export const ChatProvider = ({ children }: ChatProviderType): React.ReactElement
     }
   };
 
-  const selectDialog = async (dialog: Dialogs.Dialog): Promise<void> => {
+  const selectDialog = async (dialog?: Dialogs.Dialog): Promise<void> => {
     setSelectedDialog(dialog);
     if (!dialog) {
       return;
@@ -641,11 +641,11 @@ export const ChatProvider = ({ children }: ChatProviderType): React.ReactElement
     });
   };
 
-  const processOnMessage = (callbackFn: Chat.OnMessageListener) => {
+  const processOnMessage = (callbackFn: Chat.OnMessageListener | null) => {
     onMessageRef.current = callbackFn;
   };
 
-  const processOnMessageError = (callbackFn: Chat.OnMessageErrorListener) => {
+  const processOnMessageError = (callbackFn: Chat.OnMessageErrorListener | null) => {
     onMessageErrorRef.current = callbackFn;
   };
 

--- a/src/ChatContext.tsx
+++ b/src/ChatContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { ChatContextType, ChatProviderType, GroupChatEventType, UnreadMessagesCount } from "./types";
-import { Chat, DateOrTimestamp, Dialogs, Messages, Users } from "connectycube/dist/types/types";
+import { Chat, DateOrTimestamp, Dialogs, Messages, Users } from "connectycube/types";
 import ConnectyCube from "connectycube";
 import useStateRef from "react-usestateref";
 import { formatDistanceToNow } from "date-fns";

--- a/src/hooks/useBlockList.ts
+++ b/src/hooks/useBlockList.ts
@@ -1,4 +1,5 @@
 import ConnectyCube from "connectycube";
+import { PrivacyListAction } from "connectycube/types";
 import { useEffect, useState, useRef } from "react";
 
 export const BLOCK_LIST_LOG_TAG = "[useChat][useBlockList]";
@@ -10,11 +11,6 @@ export type BlockListHook = {
   unblockUser: (userId: number) => Promise<void>;
   blockUser: (userId: number) => Promise<void>;
 };
-
-enum PrivacyListAction {
-  ALLOW = "allow",
-  DENY = "deny",
-}
 
 function useBlockList(isConnected: boolean): BlockListHook {
   const [state, setState] = useState<Set<number>>(new Set<number>());

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,7 +22,7 @@ export interface ChatContextType extends BlockListHook {
   getDialogs: (filters?: Dialogs.ListParams) => Promise<Dialogs.Dialog[]>;
   dialogs: Dialogs.Dialog[];
   selectedDialog?: Dialogs.Dialog;
-  selectDialog: (dialog: Dialogs.Dialog) => Promise<void>;
+  selectDialog: (dialog?: Dialogs.Dialog) => Promise<void>;
   getDialogOpponentId: (dialog?: Dialogs.Dialog) => number | undefined;
   unreadMessagesCount: UnreadMessagesCount;
   users: { [userId: number]: Users.User };
@@ -45,8 +45,8 @@ export interface ChatContextType extends BlockListHook {
   lastActivity: { [userId: number]: string };
   lastMessageSentTimeString: (dialog: Dialogs.Dialog) => string;
   messageSentTimeString: (message: Messages.Message) => string;
-  processOnMessage: (fn: Chat.OnMessageListener) => void;
-  processOnMessageError: (fn: Chat.OnMessageErrorListener) => void;
+  processOnMessage: (fn: Chat.OnMessageListener | null) => void;
+  processOnMessageError: (fn: Chat.OnMessageErrorListener | null) => void;
 }
 
 export enum GroupChatEventType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Chat, Dialogs, Messages, Users } from "connectycube/dist/types/types";
+import { Chat, Dialogs, Messages, Users } from "connectycube/types";
 import { ReactNode } from "react";
 import { BlockListHook } from "../hooks/useBlockList";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,14 +10,14 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "declarationDir": "./dist/types",
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### Updates

- Added support for node 22;
- Upgraded `connectycube` >=4.2.1 to use import types and enums from "connectycube/types".