### PR TITLE
0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.26.0
+
+### Updated
+
+- Uses `connectycube@4.6.0`
+
+### Misc
+
+- Implemented `terminate` method to stop the chat connection with ability to reconnect
+- The _"SASLError: not-authorized"_ error tries to disconnect or terminate the chat connection
+
 ## 0.25.0
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Misc
 
-- Implemented `terminate` method to stop the chat connection with ability to reconnect
+- Implemented `terminate` method to stop the chat connection with the ability to reconnect
 - The _"SASLError: not-authorized"_ error tries to disconnect or terminate the chat connection
 
 ## 0.25.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@connectycube/use-chat",
   "description": "A React hook for state management in ConnectyCube-powered chat solutions",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "homepage": "https://github.com/ConnectyCube/use-chat",
   "keywords": [
     "react",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,8 +11,9 @@ export interface ChatProviderType {
 export interface ChatContextType extends BlockListHook, UsersHookExports, NetworkStatusHook {
   isConnected: boolean;
   chatStatus: ChatStatus;
-  connect: (credentials: Chat.ConnectionParams) => Promise<void>;
-  disconnect: () => void;
+  connect: (credentials: Chat.ConnectionParams) => Promise<boolean>;
+  disconnect: () => Promise<boolean>;
+  terminate: () => void;
   currentUserId?: number;
   createChat: (userId: number, extensions?: { [key: string]: any }) => Promise<Dialogs.Dialog>;
   createGroupChat: (


### PR DESCRIPTION
## 0.26.0

### Updated

- Uses `connectycube@4.6.0`

### Misc

- Implemented `terminate` method to stop the chat connection with the ability to reconnect
- The _"SASLError: not-authorized"_ error tries to disconnect or terminate the chat connection