### PR TITLE
release 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.26.1
+
+### Bug fixes
+
+- The `totalMessagesReached` state defines is determined correctly
+
 ## 0.26.0
 
 ### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectycube/use-chat",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectycube/use-chat",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@connectycube/use-chat",
   "description": "A React hook for state management in ConnectyCube-powered chat solutions",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "homepage": "https://github.com/ConnectyCube/use-chat",
   "keywords": [
     "react",

--- a/src/ChatContext.tsx
+++ b/src/ChatContext.tsx
@@ -180,7 +180,7 @@ export const ChatProvider = ({ children }: ChatProviderType): React.ReactElement
     try {
       const { items: fetchedMessages, skip, limit } = await ConnectyCube.chat.message.list(params);
       const existedMessages = messagesRef.current[dialogId] ?? [];
-      const reached = skip + limit >= fetchedMessages.length + existedMessages.length;
+      const reached = skip + limit > fetchedMessages.length + existedMessages.length;
 
       setTotalMessagesReached((prevState) => ({ ...prevState, [dialogId]: reached }));
 


### PR DESCRIPTION
## 0.26.1

### Bug fixes

- The `totalMessagesReached` state defines is determined correctly